### PR TITLE
Updated README and added support for feature_id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# tegola-postgis
+#tegola-postgis
+
+
+## This is an experiment to see how to integrate ST_AsMVT into Tegola. 
+
+The main feature of this fork is the addition of mvt data providers. These data providers cannot be
+conflated.
 
 [![Build Status](https://travis-ci.org/go-spatial/tegola.svg?branch=master)](https://travis-ci.org/go-spatial/tegola)
 [![Report Card](https://goreportcard.com/badge/github.com/go-spatial/tegola)](https://goreportcard.com/badge/github.com/go-spatial/tegola)

--- a/mvtprovider/postgis/README.md
+++ b/mvtprovider/postgis/README.md
@@ -1,5 +1,5 @@
 # PostGIS
-The PostGIS provider manages querying for tile requests against a Postgres database (version 10+) with the [PostGIS](http://postgis.net/)(version 2.4+) extension installed. The connection between tegola and Postgis is configured in a `tegola.toml` file. An example minimum connection config:
+The PostGIS provider manages querying for tile requests against a Postgres database (version 12+) with the [PostGIS](http://postgis.net/)(version 3.0+) extension installed. The connection between tegola and Postgis is configured in a `tegola.toml` file. An example minimum connection config:
 
 
 ```toml

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/geom/encoding/wkb"
+	"github.com/go-spatial/tegola-postgis"
 	"github.com/go-spatial/tegola-postgis/dict"
 	"github.com/go-spatial/tegola-postgis/proj"
 	"github.com/go-spatial/tegola-postgis/provider"
@@ -626,8 +627,11 @@ func (p Provider) MVTForLayers(ctx context.Context, tile provider.Tile, layers [
 		}
 
 		sqls = append(sqls, fmt.Sprintf(
-			`(SELECT ST_AsMVT(q,'%s') AS data FROM ( %s ) AS q)`,
+			`(SELECT ST_AsMVT(q,'%s',%d,'%s','%s') AS data FROM ( %s ) AS q)`,
 			l.Name(),
+			tegola.DefaultExtent,
+			l.GeomFieldName(),
+			l.IDFieldName(),
 			sql,
 		))
 	}


### PR DESCRIPTION
Updated README and postgis requirements.

This was necessary because the feature_id feature is not available
till postgres 12 and postgis 3.0.