### PR TITLE
MVTProvider uses providerLayerName rather than MVTName

### DIFF
--- a/atlas/map.go
+++ b/atlas/map.go
@@ -159,12 +159,15 @@ func (m Map) EncodeMVTTile(ctx context.Context, tile *slippy.Tile) ([]byte, erro
 		ptile := provider.NewTile(tile.Z, tile.X, tile.Y,
 			uint(m.TileBuffer), uint(m.SRID))
 
-		layerNames := make([]string, 0, len(m.Layers))
+		mapLayers := make([]mvtprovider.Layer, 0, len(m.Layers))
 		for i := range m.Layers {
-			layerNames = append(layerNames, m.Layers[i].MVTName())
+			mapLayers = append(mapLayers, mvtprovider.Layer{
+				Name:    m.Layers[i].ProviderLayerName,
+				MVTName: m.Layers[i].MVTName(),
+			})
 		}
 
-		return m.mvtProvider.MVTForLayers(ctx, ptile, layerNames)
+		return m.mvtProvider.MVTForLayers(ctx, ptile, mapLayers)
 	}
 
 	// tile container

--- a/mvtprovider/layer.go
+++ b/mvtprovider/layer.go
@@ -1,0 +1,11 @@
+package mvtprovider
+
+// layer holds information about a query.
+type Layer struct {
+	// Name is the name of the Layer as recognized by the provider
+	Name string
+	// MVTName is the name of the layer to encode into the MVT.
+	// this is often used when different provider layers are used
+	// at different zoom levels but the MVT layer name is consistent
+	MVTName string
+}

--- a/mvtprovider/provider.go
+++ b/mvtprovider/provider.go
@@ -14,7 +14,7 @@ type Tiler interface {
 	provider.Layerer
 
 	// MVTForLayers will return a MVT byte array or an error for the given layer names.
-	MVTForLayers(ctx context.Context, tile provider.Tile, layers []string) ([]byte, error)
+	MVTForLayers(ctx context.Context, tile provider.Tile, layers []Layer) ([]byte, error)
 }
 
 // InitFunc initialize a provider given a config map. The init function should validate the config map, and report any errors. This is called by the For function.


### PR DESCRIPTION
The MVTName() for a layer was being used to lookup provider layer
names. This caused issues when the mapLayer.name field was configured
and the providerLayerName differed from the mapLayer.Name.